### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
         "issues": "https://github.com/composer/ca-bundle/issues"
     },
     "require": {
+        "ext-openssl": "*",
+        "ext-pcre": "*",
         "php": "^5.3.2 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
add required extension dependencies.

even not all usecases require openssl extension availability, there are no checks in code to prevent fatal error when openssl functions are called. also it's very unlikely someone uses this package without openssl. the pcre extension dep is just for completeness.