### PR TITLE
dev-dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
+composer.phar
 .php_cs.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 vendor/
 composer.lock
-composer.phar
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "php": "^5.3.2 || ^7.0"
     },
     "require-dev": {
+        "psr/log": "^1.0",
         "symfony/process": "^2.5 || ^3.0"
     },
     "suggest": {


### PR DESCRIPTION
Added ``psr/log`` to require-dev
_Related to PR #1_

~~Added ``composer.phar`` to .gitignore
_``composer.lock`` is listed, but ``composer.phar`` is not... I would say either both or none should be listed..._~~