### PR TITLE
Improve usage section in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Basic usage
 
 ```php
 $curl = curl_init("https://example.org/");
-curl_setopt($curl, CURLOPT_CAINFO, \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath());
+
+$caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath());
+if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+    curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
+} else {
+    curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);
+}
+
 $result = curl_exec($curl);
 ```
 
@@ -53,11 +60,11 @@ $opts = array(
     )
 );
 
-$caPath = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
-if (is_dir($caPath)) {
-    $opts['ssl']['capath'] = $caPath;
+$caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath());
+if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+    $opts['ssl']['capath'] = $caPathOrFile;
 } else {
-    $opts['ssl']['cafile'] = $caPath;
+    $opts['ssl']['cafile'] = $caPathOrFile;
 }
 
 $context = stream_context_create($opts);


### PR DESCRIPTION
Improve documentation to avoid confusion as `\Composer\CaBundle\CaBundle::getSystemCaRootBundlePath()` can return either CA path or file.

The CURL example could lead to errors if `getSystemCaRootBundlePath()` return a path since `CURLOPT_CAINFO` expects a file and fails if it receives a path.