### PR TITLE
Update to PHPUnit 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,16 @@ dist: trusty
 
 git:
   depth: 5
-  
+
 cache:
   directories:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 env:
@@ -26,7 +25,7 @@ env:
 matrix:
   include:
     - dist: precise
-      php: 5.3
+      php: 5.6
   fast_finish: true
   allow_failures:
     - php: nightly

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ composer require composer/ca-bundle
 Requirements
 ------------
 
-* PHP 5.3.2 is required but using the latest version of PHP is highly recommended.
+* PHP 5.6 is required but using the latest version of PHP is highly recommended.
 
 
 Basic usage

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "require": {
         "ext-openssl": "*",
         "ext-pcre": "*",
-        "php": "^5.3.2 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5",
+        "phpunit/phpunit": "^5.7",
         "psr/log": "^1.0",
         "symfony/process": "^2.5 || ^3.0"
     },
@@ -51,7 +51,7 @@
     },
     "config": {
         "platform": {
-            "php": "5.3.9"
+            "php": "5.6"
         }
     }
 }

--- a/tests/CaBundleTest.php
+++ b/tests/CaBundleTest.php
@@ -4,8 +4,9 @@ namespace Composer\CaBundle;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\PhpProcess;
+use PHPUnit\Framework\TestCase;
 
-class CaBundleTest extends \PHPUnit_Framework_TestCase
+class CaBundleTest extends TestCase
 {
     public function testCaPath()
     {
@@ -86,7 +87,7 @@ class CaBundleTest extends \PHPUnit_Framework_TestCase
 
     public function testIsOpensslParseSafeTrue()
     {
-        $stub = $this->getMock('Composer\CaBundle\CaBundleMock');
+        $stub = $this->createMock('Composer\CaBundle\CaBundleMock');
         $stub->method('isOpensslParseSafe')->willReturn(true);
 
         $this->assertTrue($stub->isOpensslParseSafe());
@@ -94,7 +95,7 @@ class CaBundleTest extends \PHPUnit_Framework_TestCase
 
     public function testIsOpensslParseSafeFalse()
     {
-        $stub = $this->getMock('Composer\CaBundle\CaBundleMock');
+        $stub = $this->createMock('Composer\CaBundle\CaBundleMock');
         $stub->method('isOpensslParseSafe')->willReturn(false);
 
         $this->assertFalse($stub->isOpensslParseSafe());


### PR DESCRIPTION
I updated PHPUnit to `^5.7`, and dropped support to PHP versions `5.4` and `5.5`, as [PHPUnit 5 requires PHP `5.6`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.0.md#removed-1).

### Why dropped support for PHP versions `5.4` and `5.5`?
These versions are [no longer supported by PHP](http://php.net/supported-versions.php).

### Why PHPUnit 5.7 and not PHPUnit 6?
Because [PHPUnit 6 requires PHP 7](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#removed), and we will need to work on that.

I use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class and change `getMock` method to `createMock`.[ `getMock` was deprecated in PHPUnit 5.4](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#changed-2) and this will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Also, added `PHP 7.2` to `Travis CI` and `PHP 5.6` as minimum version in `Requirements` section :rocket: 