### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^5.3.2 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5",
+        "phpunit/phpunit": "^4.8.35",
         "psr/log": "^1.0",
         "symfony/process": "^2.5 || ^3.0"
     },

--- a/tests/CaBundleTest.php
+++ b/tests/CaBundleTest.php
@@ -4,8 +4,9 @@ namespace Composer\CaBundle;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\PhpProcess;
+use PHPUnit\Framework\TestCase;
 
-class CaBundleTest extends \PHPUnit_Framework_TestCase
+class CaBundleTest extends TestCase
 {
     public function testCaPath()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.