### PR TITLE
copy CA bundle to a temporary file when it is bundled in a PHAR file

### DIFF
--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -130,7 +130,24 @@ class CaBundle
      */
     public static function getBundledCaBundlePath()
     {
-        return __DIR__.'/../res/cacert.pem';
+        $caBundleFile = __DIR__.'/../res/cacert.pem';
+
+        // cURL does not understand 'phar://' paths
+        // see https://github.com/composer/ca-bundle/issues/10
+        if (0 === strpos($caBundleFile, 'phar://')) {
+            file_put_contents(
+                $tempCaBundleFile = tempnam(sys_get_temp_dir(), 'openssl-ca-bundle-'),
+                file_get_contents($caBundleFile)
+            );
+
+            register_shutdown_function(function() use ($tempCaBundleFile) {
+                @unlink($tempCaBundleFile);
+            });
+
+            $caBundleFile = $tempCaBundleFile;
+        }
+
+        return $caBundleFile;
     }
 
     /**


### PR DESCRIPTION
Resolves issue #10 with the same approach as `amphp/socket` mentioned in that thread.

Not yet sure about how to unit test that new execution branch, though.