### PR TITLE
Remove the read link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Basic usage
 $curl = curl_init("https://example.org/");
 
 $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
-if (is_dir($caPathOrFile)){
+if (is_dir($caPathOrFile)) {
     curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
 } else {
     curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Basic usage
 $curl = curl_init("https://example.org/");
 
 $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
-if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+if (is_dir($caPathOrFile)){
     curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
 } else {
     curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);
@@ -61,7 +61,7 @@ $opts = array(
 );
 
 $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
-if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+if (is_dir($caPathOrFile)) {
     $opts['ssl']['capath'] = $caPathOrFile;
 } else {
     $opts['ssl']['cafile'] = $caPathOrFile;


### PR DESCRIPTION
PHP documents 

If filename is a symbolic or hard link then the link will be resolved and checked. 

https://www.php.net/manual/en/function.is-dir.php

I've not seen a case where the or is needed ?