### PR TITLE
Add back suppression for openbase dir

### DIFF
--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -306,11 +306,11 @@ EOT;
 
     private static function caFileUsable($certFile, LoggerInterface $logger = null)
     {
-        return $certFile && is_file($certFile) && is_readable($certFile) && static::validateCaFile($certFile, $logger);
+        return $certFile && @is_file($certFile) && @is_readable($certFile) && static::validateCaFile($certFile, $logger);
     }
 
     private static function caDirUsable($certDir)
     {
-        return $certDir && is_dir($certDir) && is_readable($certDir);
+        return $certDir && @is_dir($certDir) && @is_readable($certDir);
     }
 }


### PR DESCRIPTION
The last lot of file locations had @ suppressions. 

Could maybe filter by the value of openbasedir so doesn't even try to read them if it's outside of that 

This is a quick fix to fix the reported error