### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       php: 5.4
     - dist: trusty
       php: 5.5
-    - dist: trusty
+    - dist: xenial
       php: 5.6
     - dist: xenial
       php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: php
-sudo: false
-dist: trusty
 
 git:
   depth: 5
@@ -15,17 +13,26 @@ env:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4snapshot
-    - php: nightly
+    - dist: precise
+      php: 5.3
+    - dist: trusty
+      php: 5.4
+    - dist: trusty
+      php: 5.5
+    - dist: trusty
+      php: 5.6
+    - dist: xenial
+      php: 7.0
+    - dist: bionic
+      php: 7.1
+    - dist: bionic
+      php: 7.2
+    - dist: bionic
+      php: 7.3
+    - dist: bionic
+      php: 7.4
+    - dist: bionic
+      php: nightly
   fast_finish: true
   allow_failures:
     - php: nightly


### PR DESCRIPTION
Test on stable PHP 7.4, and use latest distributions available on travis.