### PR TITLE
Avoid the getenv function when unsafe

### DIFF
--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -71,11 +71,15 @@ class CaBundle
 
         // If SSL_CERT_FILE env variable points to a valid certificate/bundle, use that.
         // This mimics how OpenSSL uses the SSL_CERT_FILE env variable.
-        $caBundlePaths[] = getenv('SSL_CERT_FILE');
+        if (isset($_SERVER['SSL_CERT_FILE'])) {
+            $caBundlePaths[] = $_SERVER['SSL_CERT_FILE'];
+        }
 
         // If SSL_CERT_DIR env variable points to a valid certificate/bundle, use that.
         // This mimics how OpenSSL uses the SSL_CERT_FILE env variable.
-        $caBundlePaths[] = getenv('SSL_CERT_DIR');
+        if (isset($_SERVER['SSL_CERT_FILE'])) {
+            $caBundlePaths[] = $_SERVER['SSL_CERT_DIR'];
+        }
 
         $caBundlePaths[] = ini_get('openssl.cafile');
         $caBundlePaths[] = ini_get('openssl.capath');

--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -305,7 +305,7 @@ EOT;
             return (string) $_SERVER[$name];
         }
 
-        if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false) {
+        if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false && $value !== null) {
             return (string) $value;
         }
 

--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -71,15 +71,11 @@ class CaBundle
 
         // If SSL_CERT_FILE env variable points to a valid certificate/bundle, use that.
         // This mimics how OpenSSL uses the SSL_CERT_FILE env variable.
-        if (isset($_SERVER['SSL_CERT_FILE'])) {
-            $caBundlePaths[] = $_SERVER['SSL_CERT_FILE'];
-        }
+        $caBundlePaths[] = self::getEnvVariable('SSL_CERT_FILE');
 
         // If SSL_CERT_DIR env variable points to a valid certificate/bundle, use that.
         // This mimics how OpenSSL uses the SSL_CERT_FILE env variable.
-        if (isset($_SERVER['SSL_CERT_FILE'])) {
-            $caBundlePaths[] = $_SERVER['SSL_CERT_DIR'];
-        }
+        $caBundlePaths[] = self::getEnvVariable('SSL_CERT_DIR');
 
         $caBundlePaths[] = ini_get('openssl.cafile');
         $caBundlePaths[] = ini_get('openssl.capath');
@@ -301,6 +297,19 @@ EOT;
         self::$caFileValidity = array();
         self::$caPath = null;
         self::$useOpensslParse = null;
+    }
+
+    private static function getEnvVariable($name)
+    {
+        if (isset($_SERVER[$name])) {
+            return (string) $_SERVER[$name];
+        }
+
+        if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false) {
+            return (string) $value;
+        }
+
+        return false;
     }
 
     private static function caFileUsable($certFile, LoggerInterface $logger = null)


### PR DESCRIPTION
#### TLDR: `getenv` is not thread safe!

Obviously this doesn't matter when this library is using with composer running in the console, but it does matter when this code is running on a web server. The `genv` and `putenv` functions are not threadsafe, so environment variables set in one thread using `putenv` may leak into another via `getenv`, causing the wrong values to be read.

This not just a "theoretical" bug. It actually happens in real apps and serves, and was the result of hundreds of bug reports on the Laravel framework over the years, where people were confused by variables not being what they expected!

---

EDIT: In order to minimize breakage, for CLI apps, I've allowed to still read from `getenv` for that.

NOTE: This will have essentially NO effect on anyone using the composer binary from the command line. This PR only affects people using this library in some code not running in the console.