### PR TITLE
Update CA bundle to 2021-09-30

### DIFF
--- a/res/cacert.pem
+++ b/res/cacert.pem
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Mon Jul  5 21:35:54 2021 GMT
+## Certificate data from Mozilla as of: Thu Sep 30 03:12:05 2021 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -15,8 +15,6 @@
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.28.
 ## SHA256: c8f6733d1ff4e6a4769c182971a1234f95ae079247a9c439a13423fe8ba5c24f
-##
-## Modified to remove expiring DST Root CA X3: 2021-09-25.
 ##
 
 


### PR DESCRIPTION
This official version removes expired DST Root CA X3

I guess this doesn't need a release (it just shows the history so we don't have to check future versions).