### PR TITLE
Update cacert.pem automatically

### DIFF
--- a/.github/workflows/cacert.yml
+++ b/.github/workflows/cacert.yml
@@ -1,0 +1,36 @@
+name: "Update cacert.pem"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Midnight - every night
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+
+      - name: Download cacert.pem
+        working-directory: res
+        run: curl -O https://curl.se/ca/cacert.pem
+
+      - name: Check SHA256SUM
+        working-directory: res
+        run: |
+          curl -O https://curl.se/ca/cacert.pem.sha256
+          sha256sum -c cacert.pem.sha256
+          rm -f cacert.pem.sha256
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'Update cacert.pem'
+          body: |
+            Update cacert.pem using latest from https://curl.se/docs/caextract.html
+          commit-message: Update cacert.pem
+          delete-branch: true
+          add-paths: |
+            res/cacert.pem


### PR DESCRIPTION
res/cacert.pem is currently out of date with the version on https://curl.se/docs/caextract.html

Relates to https://github.com/composer/ca-bundle/issues/32

I believe the workflow should work fine without needing to create any new accounts / personal access tokens. `GITHUB_TOKEN` is predefined, and is only restricted on `push` / `pull_request` events.