### PR TITLE
add missing openssl-certificate paths for homebrew on apple silicon

### DIFF
--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -95,6 +95,8 @@ class CaBundle
             '/usr/local/etc/ssl/cert.pem', // FreeBSD 10.x
             '/usr/local/etc/openssl/cert.pem', // OS X homebrew, openssl package
             '/usr/local/etc/openssl@1.1/cert.pem', // OS X homebrew, openssl@1.1 package
+            '/opt/homebrew/etc/openssl@3/cert.pem', // macOS silicon homebrew, openssl@3 package
+            '/opt/homebrew/etc/openssl@1.1/cert.pem', // macOS silicon homebrew, openssl@1.1 package
         );
 
         foreach($otherLocations as $location) {


### PR DESCRIPTION
As documented in https://docs.brew.sh/Installation the homebrew install-location has changed on apple silicon. 

> The script installs Homebrew to its default, supported, best prefix (/opt/homebrew for Apple Silicon, /usr/local for macOS Intel and /home/linuxbrew/.linuxbrew for Linux)

Therefore it seems to me advisable to add the new paths for apple silicon installation to the list of openssl ca-bundle-paths. This PR does it, as requested in https://github.com/composer/getcomposer.org/pull/236#issuecomment-1945830254

Cheers 🍻 