### PR TITLE
feat: apply strict types and other improvements for php 8.4

### DIFF
--- a/tests/CaBundleTest.php
+++ b/tests/CaBundleTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Composer\CaBundle;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\PhpProcess;
 use PHPUnit\Framework\TestCase;
 
-class CaBundleTest extends TestCase
+final class CaBundleTest extends TestCase
 {
     public function testCaPath(): void
     {
@@ -113,8 +115,6 @@ class CaBundleTest extends TestCase
     {
         $certDir = 'SSL_CERT_DIR=';
         $certFile = 'SSL_CERT_FILE=';
-        $sslCaFile = 'openssl.cafile';
-        $sslCaPath = 'openssl.capath';
 
         $this->setEnv($certDir);
         $this->setEnv($certFile);


### PR DESCRIPTION
Applied rules:
 * LongArrayToShortArray
 * RemoveUnusedVariableAssign
 * FinalizeTestCaseClass
 * DeclareStrictTypes
 * FlipTypeControlToUseExclusiveType
 * CompleteMissingIfElseBracket
 * ExplicitBoolCompare
 * SimplifyIfElseToTernary
 * CountArrayToEmptyArrayComparison
 * NewlineAfterStatement
 * RemoveUselessParamTag
 * RemoveUselessReturnTag
 * BinaryOpNullableToInstanceof
 * AddMethodCallBasedStrictParamType
 * AddVoidReturnTypeWhereNoReturn
 * BoolReturnTypeFromBooleanConstReturns
 * BoolReturnTypeFromBooleanStrictReturns
 * StringReturnTypeFromStrictStringReturns
 * AddClosureVoidReturnTypeWhereNoReturn
 
 Related https://github.com/composer/pcre/pull/43
