### PR TITLE
Fix Fedora default path

### DIFF
--- a/src/CaBundle.php
+++ b/src/CaBundle.php
@@ -81,7 +81,8 @@ class CaBundle
         $caBundlePaths[] = ini_get('openssl.capath');
 
         $otherLocations = array(
-            '/etc/pki/tls/certs/ca-bundle.crt', // Fedora, RHEL, CentOS (ca-certificates package)
+            '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', // Fedora, RHEL, CentOS (ca-certificates package) - NEW
+            '/etc/pki/tls/certs/ca-bundle.crt', // Fedora, RHEL, CentOS (ca-certificates package) - Deprecated
             '/etc/ssl/certs/ca-certificates.crt', // Debian, Ubuntu, Gentoo, Arch Linux (ca-certificates package)
             '/etc/ssl/ca-bundle.pem', // SUSE, openSUSE (ca-certificates package)
             '/usr/ssl/certs/ca-bundle.crt', // Cygwin


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile

The new path available on all version of Fedora, CentoS, RHEL and Clones

```
# file /etc/pki/tls/certs/ca-bundle.crt
/etc/pki/tls/certs/ca-bundle.crt: symbolic link to /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
# file /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem: ASCII text
```

Perhaps the deprecated path can be removed, I kept it for safety